### PR TITLE
add extra  /* in command line

### DIFF
--- a/AutoDock.py
+++ b/AutoDock.py
@@ -41,7 +41,7 @@ Here is a video explaning how to perform virtual screaning using AutoDock Vina
 and how to use this script:
 
 For running on a local computer use this command:
-for file in ./Ligands/*; do tmp=${file%.pdbqt}; name="${tmp##*/}"; ./vina --receptor receptor.pdbqt --ligand "$file" --out $name_out.pdbqt --log $name.log --exhaustiveness 10 --center_x 0 --center_y 0 --center_z 10 --size_x 15 --size_y 15 --size_z 15; awk '/^[-+]+$/{getline;print FILENAME,$0}' $name.log >> temp; done; sort temp -nk 3 > Results; rm temp; mkdir logs; mv *.log *.out logs
+for file in ./Ligands/*/*; do tmp=${file%.pdbqt}; name="${tmp##*/}"; ./vina --receptor receptor.pdbqt --ligand "$file" --out $name_out.pdbqt --log $name.log --exhaustiveness 10 --center_x 0 --center_y 0 --center_z 10 --size_x 15 --size_y 15 --size_z 15; awk '/^[-+]+$/{getline;print FILENAME,$0}' $name.log >> temp; done; sort temp -nk 3 > Results; rm temp; mkdir logs; mv *.log *.out logs
 --------------------------------------------------------------------------------
 MIT License
 


### PR DESCRIPTION
Hi Sari,

Thank you very much for providing AutoDock vina Tutorial. It was awesome!

In your video, I did step by step to ran the simulation in my local computer and I got this error:
"Parse error on line 0 in file "./Ligands/9": No atoms in the ligand"

I found a bug in your command line:
"./Ligands/*" should be replaced by "./Ligands/*/*" to let vina reads the ligands inside the folders (1 , 2 , 3 , ...) in Ligands folder. 

Thank you,
Nasim 

